### PR TITLE
feat: 调整仓库名 sealdice-manual-next 为 sealdice-manual

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   docs:
     runs-on: ubuntu-latest
-    if: (github.repository == 'sealdice/sealdice-manual-next' && github.ref_name == 'main') || github.repository != 'sealdice/sealdice-manual-next'
+    if: (github.repository == 'sealdice/sealdice-manual' && github.ref_name == 'main') || github.repository != 'sealdice/sealdice-manual'
 
     steps:
       - uses: actions/checkout@v3
@@ -35,7 +35,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push changes
-        if: github.repository == 'sealdice/sealdice-manual-next'
+        if: github.repository == 'sealdice/sealdice-manual'
         env:
           KEY: ${{ secrets.KEY }}
           URL: ${{ secrets.URL }}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# sealdice-manual-next
+# sealdice-manual
 
 VuePress2 驱动的海豹骰全新官方使用手册。
 
-当前手册预览可见 [海豹手册](https://sealdice.github.io/sealdice-manual-next/)。
+当前手册预览可见 [海豹手册](https://sealdice.github.io/sealdice-manual/)。
 
 ## 编写文档
 
@@ -30,7 +30,7 @@ pnpm run docs:dev
 
 ## 将自己的分支发布为 GitHub Pages
 
-[主仓库](https://github.com/sealdice/sealdice-manual-next) 的 [Pages](https://sealdice.github.io/sealdice-manual-next/) 自动追踪主仓库的 main 分支。
+[主仓库](https://github.com/sealdice/sealdice-manual) 的 [Pages](https://sealdice.github.io/sealdice-manual/) 自动追踪主仓库的 main 分支。
 
 如果你希望请其他人预览修改的效果，或者有其他需求，需要将自己的分支也发布为 GitHub Pages。
 

--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -7,7 +7,7 @@ import { cut } from "@node-rs/jieba";
 
 import theme from "./theme";
 
-const basePath: any = process.env.BASE_PATH ?? "/sealdice-manual-next/";
+const basePath: any = process.env.BASE_PATH ?? "/sealdice-manual/";
 
 export default defineUserConfig({
   base: basePath,

--- a/docs/.vuepress/theme.ts
+++ b/docs/.vuepress/theme.ts
@@ -23,7 +23,7 @@ export default hopeTheme({
   pageInfo: ["ReadingTime"],
   contributors: false,
   editLink: false,
-  docsRepo: "sealdice/sealdice-manual-next",
+  docsRepo: "sealdice/sealdice-manual",
   docsBranch: "main",
   displayFooter: false,
   home: "/index.md",

--- a/docs/about/about.md
+++ b/docs/about/about.md
@@ -21,7 +21,7 @@ title: 关于
 
 ## 手册贡献者
 
-[**新手册贡献者**](https://github.com/sealdice/sealdice-manual-next/graphs/contributors)
+[**新手册贡献者**](https://github.com/sealdice/sealdice-manual/graphs/contributors)
 
 ---
 

--- a/docs/about/develop.md
+++ b/docs/about/develop.md
@@ -12,7 +12,7 @@ title: 参与项目
 几个比较重要的仓库：
 - [核心](https://github.com/sealdice/sealdice-core)：海豹的 Go 后端代码仓库，这个仓库也作为海豹的主仓库，Bug 可反馈在该仓库的 issue 中；
 - [UI](https://github.com/sealdice/sealdice-ui)：海豹的前端代码，基于 Vue3 + ElementPlus 开发；
-- [手册（新）](https://github.com/sealdice/sealdice-manual-next)：海豹新版官方手册（即当前的手册）的源码，如对手册有什么改进内容可以在该项目提交 pr；
+- [手册](https://github.com/sealdice/sealdice-manual)：海豹官方手册（即当前的手册）的源码，如对手册有什么改进内容可以在该项目提交 pr；
 - [构建](https://github.com/sealdice/sealdice-build)：海豹的自动构建仓库，用于自动化发布海豹的每日构建包与 Release；
 - ……
 
@@ -50,7 +50,7 @@ title: 参与项目
 
 ### 对目标仓库进行 fork
 
-首先 fork 对应想要修改的仓库，此处以手册仓库 [sealdice-manual-next](https://github.com/sealdice/sealdice-manual-next) 为例：
+首先 fork 对应想要修改的仓库，此处以手册仓库 [sealdice-manual](https://github.com/sealdice/sealdice-manual) 为例：
 
 ![fork 对应仓库](./images/develop-fork-1.png)
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sealdice-manual-next",
+  "name": "sealdice-manual",
   "version": "1.0.0",
   "description": "海豹骰全新官方使用手册。",
   "main": "index.js",


### PR DESCRIPTION
目前新手册已经稳定，旧手册也已经完全弃用，故提议调整该仓库名。
该调整主要会影响到各处（包括用户群的帮助 bot）对 https://sealdice.github.io/sealdice-manual-next/ 这个链接的引用。